### PR TITLE
feat: add orange accent and lighten palette

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,10 +2,10 @@
             --bg: #1a1a1a;
             --bg-light: #2d2d2d;
             --text: #e8e8e8;
-            --accent: #4a9eff;
+            --accent: #5fa9ff;
             --accent-secondary: #00d4aa;
-            --accent-tertiary: #ff6b35;
-            --gray: #888888;
+            --accent-tertiary: #ffad00;
+            --gray: #9e9e9e;
             --green: #00c851;
             --warning: #ffbb33;
             --radius: 8px;
@@ -555,14 +555,15 @@
             gap: 1rem; 
         }
 
-        .footer-call { 
-            background: transparent; 
+        .footer-call {
+            background: transparent;
             border: 1px solid var(--accent);
             color: var(--accent);
         }
 
         .footer-call:hover {
-            background: var(--accent);
+            background: var(--accent-tertiary);
+            border-color: var(--accent-tertiary);
             color: white;
         }
 


### PR DESCRIPTION
## Summary
- refresh palette with lighter blue and gray variables
- introduce orange `#ffad00` accent and apply to footer call button

## Testing
- `npm test` *(fails: could not read package.json)*
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_6894badb3ad4832c8934ed6f9e73f37c