### PR TITLE
Refactor service admin and contact panel

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,91 @@
+let services = [];
+
+async function checkLogin() {
+  const res = await fetch('../api/check_login.php');
+  const data = await res.json();
+  if (data.admin) {
+    initAdmin();
+  }
+}
+
+document.getElementById('loginForm').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value.trim();
+  const res = await fetch('../api/login.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    initAdmin();
+  } else {
+    alert('Неверные данные');
+  }
+});
+
+async function initAdmin() {
+  document.getElementById('loginSection').style.display = 'none';
+  document.getElementById('adminSection').style.display = 'block';
+  await loadServices();
+  loadAdminServices();
+}
+
+async function loadServices() {
+  const res = await fetch('../api/services.php');
+  services = await res.json();
+}
+
+function loadAdminServices() {
+  const container = document.getElementById('adminServicesList');
+  container.innerHTML = '';
+  services.forEach(service => {
+    const item = document.createElement('div');
+    item.className = 'service-item';
+    item.innerHTML = `
+      <h4>${service.name}</h4>
+      <p>${service.description}</p>
+      <div class="service-actions">
+        <button class="btn btn-small btn-danger" onclick="deleteService(${service.id})">Удалить</button>
+      </div>
+    `;
+    container.appendChild(item);
+  });
+}
+
+async function addService() {
+  const name = document.getElementById('serviceName').value.trim();
+  const description = document.getElementById('serviceDescription').value.trim();
+  const featuresText = document.getElementById('serviceFeatures').value;
+  if (!name || !description) {
+    alert('Заполните все поля');
+    return;
+  }
+  const features = featuresText.split('\n').map(f => f.trim()).filter(Boolean);
+  const res = await fetch('../api/services.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, description, features })
+  });
+  if (res.ok) {
+    document.getElementById('serviceName').value = '';
+    document.getElementById('serviceDescription').value = '';
+    document.getElementById('serviceFeatures').value = '';
+    await loadServices();
+    loadAdminServices();
+    alert('Услуга добавлена!');
+  } else {
+    alert('Не удалось сохранить услугу');
+  }
+}
+
+async function deleteService(id) {
+  if (!confirm('Удалить эту услугу?')) return;
+  const res = await fetch(`../api/services.php?id=${id}`, { method: 'DELETE' });
+  if (res.ok) {
+    await loadServices();
+    loadAdminServices();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', checkLogin);

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,37 @@
+<?php
+require __DIR__.'/../api/db.php';
+?>
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Админ - услуги</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <div id="loginSection" class="admin-login">
+        <h2>Вход администратора</h2>
+        <form id="loginForm">
+            <input type="text" id="username" placeholder="Логин">
+            <input type="password" id="password" placeholder="Пароль">
+            <button type="submit" class="btn accent">Войти</button>
+        </form>
+    </div>
+
+    <div id="adminSection" class="admin-content" style="display:none">
+        <div class="admin-header">
+            <h2>Управление услугами</h2>
+        </div>
+        <div class="service-form">
+            <h3>Добавить новую услугу</h3>
+            <input type="text" id="serviceName" placeholder="Название услуги">
+            <textarea id="serviceDescription" rows="4" placeholder="Описание услуги"></textarea>
+            <textarea id="serviceFeatures" rows="3" placeholder="Особенности (каждая с новой строки)"></textarea>
+            <button class="btn accent" onclick="addService()">Добавить услугу</button>
+        </div>
+        <div class="service-list" id="adminServicesList"></div>
+    </div>
+
+    <script src="admin.js"></script>
+</body>
+</html>

--- a/api/config.php
+++ b/api/config.php
@@ -3,6 +3,5 @@ return [
     'host' => 'u937314v.beget.tech',
     'database' => 'u937314v_presfor',
     'username' => 'u937314v_presfor',
-    'password' => 'rTkYA!z7TpN4',
-    'admin_password' => 'admin123'
+    'password' => 'rTkYA!z7TpN4'
 ];

--- a/api/login.php
+++ b/api/login.php
@@ -1,9 +1,17 @@
 <?php
 require __DIR__.'/db.php';
 header('Content-Type: application/json');
+
 $data = json_decode(file_get_contents('php://input'), true);
+$username = $data['username'] ?? '';
 $password = $data['password'] ?? '';
-if ($password === $config['admin_password']) {
+
+$db = get_db();
+$stmt = $db->prepare('SELECT password_hash FROM admins WHERE username = ?');
+$stmt->execute([$username]);
+$admin = $stmt->fetch();
+
+if ($admin && password_verify($password, $admin['password_hash'])) {
     $_SESSION['admin'] = true;
     echo json_encode(['status' => 'ok']);
 } else {

--- a/api/setup.php
+++ b/api/setup.php
@@ -7,4 +7,18 @@ $db->exec("CREATE TABLE IF NOT EXISTS services (
     description TEXT NOT NULL,
     features TEXT NOT NULL
 )");
+
+$db->exec("CREATE TABLE IF NOT EXISTS admins (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL
+)");
+
+$exists = $db->query('SELECT COUNT(*) FROM admins')->fetchColumn();
+if (!$exists) {
+    $hash = password_hash('admin123', PASSWORD_DEFAULT);
+    $stmt = $db->prepare('INSERT INTO admins (username, password_hash) VALUES (?, ?)');
+    $stmt->execute(['admin', $hash]);
+}
+
 echo "Tables created";

--- a/css/style.css
+++ b/css/style.css
@@ -757,6 +757,20 @@ body.theme-soft {
             z-index: 2000;
         }
 
+        .contact-links {
+            list-style: none;
+            padding: 0;
+        }
+
+        .contact-links li {
+            margin-bottom: 0.5rem;
+        }
+
+        .contact-links a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
         .popup.open { 
             visibility: visible; 
             opacity: 1; 

--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@
                     <div class="hero-content">
                         <h1>Профессиональное изготовление и ремонт пресс-форм</h1>
                         <p>Более 10 лет опыта, 98% форм запускаются без доработок, расчет за 24 часа</p>
-                        <a href="#" class="btn accent" onclick="openPopup()">Связаться с нами</a>
+                        <a href="#" class="btn accent" onclick="openContacts()">Связаться с нами</a>
                     </div>
                 </div>
             </div>
@@ -169,7 +169,7 @@
                 <div class="container">
                     <h3>-------------------------</h3>
                     <p>------------------------------</p>
-                    <a href="#" class="btn secondary" onclick="openPopup()">Отправить заявку</a>
+                    <a href="#" class="btn secondary" onclick="openContacts()">Отправить заявку</a>
                 </div>
             </div>
         </section>
@@ -310,38 +310,18 @@
         </div>
     </footer>
 
-    <!-- Admin Toggle Button -->
-    <button class="admin-toggle" id="adminToggle" onclick="toggleAdmin()">⚙️</button>
-    
-    <!-- Admin Panel -->
-    <div class="admin-panel" id="adminPanel">
+    <!-- Contact Panel -->
+    <div class="admin-panel" id="contactPanel">
         <div class="admin-content">
             <div class="admin-header">
-                <h2>Управление услугами</h2>
-                <button class="close-admin" onclick="closeAdmin()">✕</button>
+                <h2>Связаться с нами</h2>
+                <button class="close-admin" onclick="closeContacts()">✕</button>
             </div>
-            
-            <div class="service-form">
-                <h3>Добавить новую услугу</h3>
-                <input type="text" id="serviceName" placeholder="Название услуги">
-                <textarea id="serviceDescription" rows="4" placeholder="Описание услуги"></textarea>
-                <textarea id="serviceFeatures" rows="3" placeholder="Особенности (каждая с новой строки)"></textarea>
-                <button class="btn accent" onclick="addService()">Добавить услугу</button>
-            </div>
-            
-            <div class="service-list" id="adminServicesList">
-                <!-- Admin services list will be loaded here -->
-            </div>
-        </div>
-    </div>
-
-    <!-- Popup -->
-    <div class="popup" id="popup">
-        <div class="popup-content">
-            <button class="popup-close" onclick="closePopup()">&times;</button>
-            <h3>Связаться с нами</h3>
-            <p>Заполните форму в разделе "Контакты" или свяжитесь с нами по телефону</p>
-            <a href="#" class="btn accent" onclick="closePopup(); showPage('contacts')">Перейти к форме</a>
+            <ul class="contact-links">
+                <li><a href="https://t.me/yourcompany" target="_blank">Telegram</a></li>
+                <li><a href="https://wa.me/yourcompany" target="_blank">WhatsApp</a></li>
+                <li><a href="https://vk.com/yourcompany" target="_blank">VK</a></li>
+            </ul>
         </div>
     </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -40,97 +40,12 @@ async function loadServices() {
   });
 }
 
-function openAdmin() {
-  document.getElementById('adminPanel').classList.add('open');
-  loadAdminServices();
+function openContacts() {
+  document.getElementById('contactPanel').classList.add('open');
 }
 
-function closeAdmin() {
-  document.getElementById('adminPanel').classList.remove('open');
-}
-
-async function toggleAdmin() {
-  const panel = document.getElementById('adminPanel');
-  if (panel.classList.contains('open')) {
-    closeAdmin();
-    return;
-  }
-  const status = await fetch('api/check_login.php').then(r => r.json());
-  if (!status.admin) {
-    const password = prompt('Введите пароль');
-    if (!password) return;
-    const login = await fetch('api/login.php', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password })
-    });
-    if (!login.ok) {
-      alert('Неверный пароль');
-      return;
-    }
-  }
-  openAdmin();
-}
-
-function loadAdminServices() {
-  const container = document.getElementById('adminServicesList');
-  container.innerHTML = '';
-  services.forEach(service => {
-    const item = document.createElement('div');
-    item.className = 'service-item';
-    item.innerHTML = `
-      <h4>${service.name}</h4>
-      <p>${service.description}</p>
-      <div class="service-actions">
-        <button class="btn btn-small btn-danger" onclick="deleteService(${service.id})">Удалить</button>
-      </div>
-    `;
-    container.appendChild(item);
-  });
-}
-
-async function addService() {
-  const name = document.getElementById('serviceName').value.trim();
-  const description = document.getElementById('serviceDescription').value.trim();
-  const featuresText = document.getElementById('serviceFeatures').value;
-  if (!name || !description) {
-    alert('Заполните все поля');
-    return;
-  }
-  const features = featuresText.split('\n').map(f => f.trim()).filter(Boolean);
-  const res = await fetch('api/services.php', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, description, features })
-  });
-  if (!res.ok) {
-    alert('Не удалось сохранить услугу');
-    return;
-  }
-  document.getElementById('serviceName').value = '';
-  document.getElementById('serviceDescription').value = '';
-  document.getElementById('serviceFeatures').value = '';
-  await loadServices();
-  loadAdminServices();
-  alert('Услуга добавлена!');
-}
-
-async function deleteService(id) {
-  if (!confirm('Удалить эту услугу?')) return;
-  const res = await fetch(`api/services.php?id=${id}`, { method: 'DELETE' });
-  if (res.ok) {
-    await loadServices();
-    loadAdminServices();
-  }
-}
-
-// Popup
-function openPopup() {
-  document.getElementById('popup').classList.add('open');
-}
-
-function closePopup() {
-  document.getElementById('popup').classList.remove('open');
+function closeContacts() {
+  document.getElementById('contactPanel').classList.remove('open');
 }
 
 document.getElementById('contactForm').addEventListener('submit', function (e) {
@@ -140,18 +55,11 @@ document.getElementById('contactForm').addEventListener('submit', function (e) {
   this.reset();
 });
 
-setTimeout(openPopup, 45000);
-
 document.addEventListener('DOMContentLoaded', loadServices);
 
-document.getElementById('popup').addEventListener('click', function (e) {
-  if (e.target === this) closePopup();
-});
-
 document.addEventListener('click', function (e) {
-  const panel = document.getElementById('adminPanel');
-  const toggle = document.getElementById('adminToggle');
-  if (panel.classList.contains('open') && !panel.contains(e.target) && !toggle.contains(e.target)) {
-    closeAdmin();
+  const panel = document.getElementById('contactPanel');
+  if (panel.classList.contains('open') && !panel.contains(e.target)) {
+    closeContacts();
   }
 });

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -4,3 +4,13 @@ CREATE TABLE IF NOT EXISTS services (
     description TEXT NOT NULL,
     features TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS admins (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL
+);
+
+INSERT INTO admins (username, password_hash) VALUES
+('admin', '$2y$12$3sa/aTZWtXhoBkMjijgCMecyr8CCmQnSLk0BdxJ/jjRUEm8Njcgb2')
+ON DUPLICATE KEY UPDATE username=username;


### PR DESCRIPTION
## Summary
- Add admin table and hashed-password login backed by database
- Move service management to separate /admin page
- Replace service popup with contact links panel

## Testing
- `php -l api/login.php`
- `php -l admin/index.php`
- `node -c js/app.js`
- `node -c admin/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6894f8e0d304832cb3679386b380e1de